### PR TITLE
Arregla algunos errores en el back de orgs

### DIFF
--- a/src/backend/api/serializers.py
+++ b/src/backend/api/serializers.py
@@ -55,7 +55,6 @@ class UserDataSerializer(serializers.ModelSerializer):
         read_only_fields = ["user", "id"]
         extra_kwargs = {"user": {"read_only": True}}
         
-        
 class OrganizationSerializer(serializers.ModelSerializer):
     class Meta:
         model = Organization


### PR DESCRIPTION
This pull request focuses on improving the organization and readability of the `src/backend/api/views.py` file by restructuring imports and cleaning up comments. Additionally, it includes a minor change in `src/backend/api/serializers.py`.

### Codebase organization and readability improvements:

* [`src/backend/api/views.py`](diffhunk://#diff-0059d4d900eddb32eeec737a601eb4d94d8496c5c552cefc544c4d4179f5ae7dR21-R48): Restructured imports by grouping them into Django imports, Django REST Framework imports, and project-specific imports. This improves the readability and maintainability of the file.
* [`src/backend/api/views.py`](diffhunk://#diff-0059d4d900eddb32eeec737a601eb4d94d8496c5c552cefc544c4d4179f5ae7dL111-L116): Removed unnecessary comments and adjusted the placement of the `permission_classes` attribute in the `OrganizationCreateView` class. This helps to clean up the code and make it more concise. [[1]](diffhunk://#diff-0059d4d900eddb32eeec737a601eb4d94d8496c5c552cefc544c4d4179f5ae7dL111-L116) [[2]](diffhunk://#diff-0059d4d900eddb32eeec737a601eb4d94d8496c5c552cefc544c4d4179f5ae7dL134) [[3]](diffhunk://#diff-0059d4d900eddb32eeec737a601eb4d94d8496c5c552cefc544c4d4179f5ae7dL151-L175)

### Minor changes:

* [`src/backend/api/serializers.py`](diffhunk://#diff-c473b678c48368a38825de56081dcb5525220b1fa64d157dc080858558167d35L58): Removed an unnecessary blank line before the `OrganizationSerializer` class definition.